### PR TITLE
Use event constructors to create onchange and click events

### DIFF
--- a/switchery.js
+++ b/switchery.js
@@ -227,9 +227,11 @@ Switchery.prototype.colorize = function() {
  */
 
 Switchery.prototype.handleOnchange = function(state) {
-  if ("createEvent" in document) {
-    var event = document.createEvent("HTMLEvents");
-    event.initEvent("change", false, true);
+  var eve = new Event("click");
+  this.element.dispatchEvent(eve);
+
+  if (typeof Event === "function") {
+    var event = new Event("change", {cancelable: true});
     this.element.dispatchEvent(event);
   } else {
     this.element.fireEvent("onchange");


### PR DESCRIPTION
Dispatching just the onchange event doesn't call the click event handlers on the input checkbox. Also, AngularJS updates the model values in these click event handlers. 

This change triggers a click event in addition to the change event. It also uses the Event constructor for instead of using deprecated createEvent API.
