### PR TITLE
Sets a data attribute to handle multiple calls for a checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ defaults = {
 - `disabledOpacity` : opacity of the switch when it's disabled (0 to 1)
 - `speed` : length of time that the transition will take, ex. '0.4s', '1s', '2.2s' (Note: transition speed of the handle is twice shorter)
 
+## Multiple calls
+
+You can filter out existing elements that have already been called by looking for data-switchery="true"
+
 ## Examples
 
 ##### Checked

--- a/switchery.js
+++ b/switchery.js
@@ -60,7 +60,7 @@ function Switchery(element, options) {
     }
   }
 
-  if (this.element != null && this.element.type == 'checkbox' && !this.markedAsSwitched()) this.init();
+  if (this.element != null && this.element.type == 'checkbox') this.init();
 }
 
 /**


### PR DESCRIPTION
I'm using this in a SPA app that needs to "re-switcherize" checkbox when new objects get injected into the dom, or re-rendered.

I've added a simple setter & getter to handle this.
