### PR TITLE
Fix duplicated ID and name

### DIFF
--- a/switchery.js
+++ b/switchery.js
@@ -203,8 +203,8 @@ Switchery.prototype.setAttributes = function() {
   var id = this.element.getAttribute('id')
     , name = this.element.getAttribute('name');
 
-  if (id) this.switcher.setAttribute('id', id);
-  if (name) this.switcher.setAttribute('name', name);
+  if (id) this.switcher.setAttribute('id', id + 'Switchery');
+  if (name) this.switcher.setAttribute('name', name + 'Switchery');
 };
 
 /**


### PR DESCRIPTION
Switchery copy the id and name that makes the page has duplicated ID and name in the form, which is invalid.
