### PR TITLE
Prevent the text selection on double click.

### DIFF
--- a/switchery.css
+++ b/switchery.css
@@ -15,6 +15,12 @@
   position: relative;
   vertical-align: middle;
   width: 50px;
+  
+  -moz-user-select: none;
+  -khtml-user-select: none;
+  -webkit-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
 
   -webkit-box-sizing: content-box;
   -moz-box-sizing: content-box;


### PR DESCRIPTION
Avoid the text selection on double click in the element, like this:

![Screenshot](http://cl.ly/image/3b2q3Z1Y2r3l/Captura%20de%20pantalla%202014-08-21%20a%20la%28s%29%2009.31.10.png)
