### PR TITLE
Fixing issue found in IE9+ with change event dispatch

### DIFF
--- a/switchery.js
+++ b/switchery.js
@@ -213,7 +213,7 @@ Switchery.prototype.colorize = function() {
  */
 
 Switchery.prototype.handleOnchange = function(state) {
-  if (typeof Event === 'function' || !document.fireEvent) {
+  if (document.dispatchEvent) {
     var event = document.createEvent('HTMLEvents');
     event.initEvent('change', true, true);
     this.element.dispatchEvent(event);


### PR DESCRIPTION
In my app, I discovered that in IE9 the `change` event would not fire as expected. Basically,
only a handler attached via `onchange = function () { ... };` would work, all others such as
those bound via `addEventListener` would not fire at all.

After closer investigation, the condition used to test whether to use `dispatchEvent` or `fireEvent`
was not catching IE9+ correctly. (ie: `typeof Event === "object"`) so I've changed this conditional
to hopefully be simpler and more accurate.
