### PR TITLE
Fix bug in Hongmi phone

### DIFF
--- a/switchery.css
+++ b/switchery.css
@@ -25,6 +25,10 @@
   -webkit-box-sizing: content-box;
   -moz-box-sizing: content-box;
   box-sizing: content-box;
+
+  -webkit-background-clip: content-box;
+  background-clip: content-box;
+
 }
 
 .switchery > small {


### PR DESCRIPTION
In HongMi Phone ( a Chinese brand, base on Android4.2.2 ), the website looks like this:

![screenshot1](https://cloud.githubusercontent.com/assets/2987435/4441355/dc25fd9c-47d1-11e4-8baa-b6e05df701b9.jpg)

while adding the `background-clip: content-box` property, it looks ok now:

![screenshot2](https://cloud.githubusercontent.com/assets/2987435/4441362/face19dc-47d1-11e4-89ed-b09f07c858c2.jpg)
