### PR TITLE
Add Meteor.js support

### DIFF
--- a/meteor/export.js
+++ b/meteor/export.js
@@ -1,0 +1,3 @@
+/*global Switchery:true*/ // Meteor creates a file-scope global for exporting. This comment prevents a potential JSHint warning.
+Switchery = window.Switchery;
+delete window.Switchery;

--- a/meteor/tests.js
+++ b/meteor/tests.js
@@ -1,0 +1,10 @@
+'use strict';
+
+Tinytest.add('Switchery integration', function (test) {
+
+    var checkbox = document.createElement('input');
+    checkbox.className = 'js-switch';
+    var switchy = new Switchery(checkbox);
+
+    test.instanceOf(switchy, Switchery, 'instantiation OK');
+});

--- a/package.js
+++ b/package.js
@@ -1,14 +1,14 @@
 // package metadata file for Meteor.js
 'use strict';
 
-var packageName = 'mediatainment:switchery'; // https://atmospherejs.com/mediatainment/switchery
+var packageName = 'abpetkov:switchery'; // https://atmospherejs.com/mediatainment/switchery
 var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
 
 Package.describe({
     name: packageName,
     summary: 'Switchery (official) - turns your default HTML checkbox inputs into beautiful iOS 7 style switches in just few simple steps. Easy customizable to fit your design perfectly.',
     version: "0.0.1", //packageJson.version,
-    git: 'https://github.com/mediatainment/switchery'
+    git: 'https://github.com/abpetkov/switchery'
 });
 
 Package.onUse(function(api) {

--- a/package.js
+++ b/package.js
@@ -1,0 +1,24 @@
+// package metadata file for Meteor.js
+'use strict';
+
+var packageName = 'mediatainment:switchery'; // https://atmospherejs.com/mediatainment/switchery
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+
+Package.describe({
+    name: packageName,
+    summary: 'Switchery (official) - turns your default HTML checkbox inputs into beautiful iOS 7 style switches in just few simple steps. Easy customizable to fit your design perfectly.',
+    version: "0.0.1", //packageJson.version,
+    git: 'https://github.com/mediatainment/switchery'
+});
+
+Package.onUse(function(api) {
+    api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+    api.export('Switchery');
+    api.addFiles(['dist/switchery.js', 'dist/switchery.css', 'meteor/export.js'], where);
+});
+
+Package.onTest(function(api) {
+    api.use(packageName, where);
+    api.use('tinytest', where);
+    api.addFiles('meteor/tests.js', where); // testing specific files
+});

--- a/package.js
+++ b/package.js
@@ -6,7 +6,7 @@ var where = 'client'; // where to install: 'client' or 'server'. For both, pass 
 
 Package.describe({
     name: packageName,
-    summary: 'Switchery (official) - turns your default HTML checkbox inputs into beautiful iOS 7 style switches in just few simple steps. Easy customizable to fit your design perfectly.',
+    summary: 'Switchery (official) - turns your default HTML checkbox inputs into beautiful iOS 7 style switches.',
     version: "0.0.1", //packageJson.version,
     git: 'https://github.com/abpetkov/switchery'
 });

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "devDependencies": {
     "uglify-js": "~2.4.8",
     "component": "^1.0.0",
-    "uglifycss": "0.0.7"
+    "uglifycss": "0.0.7",
+    "grunt-exec": "latest",
+    "spacejam": "latest"
   }
 }


### PR DESCRIPTION
Hi abpetkov,

I'm a Meteor.js dev and volunteer package maintainer for Meteor. Switchery is a great library, and adding it to Meteor's ecosystem will expose it to many new devs (Meteor has 22k+ stars on GitHub), likely bringing in new testers and contributors.

This PR will let you directly publish updated versions of the library as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer.

I've already published the current version of the package on Atmosphere (Meteor's package directory / https://atmospherejs.com/abpetkov/switchery). When you release new versions, you can publish them to Atmosphere with grunt meteor automatically.

Thanks & best regards,
Jan
