### PR TITLE
Added missing tailing semi-colon

### DIFF
--- a/dist/switchery.js
+++ b/dist/switchery.js
@@ -1952,4 +1952,4 @@ if (typeof exports == "object") {
 } else {
   (this || window)["Switchery"] = require("switchery");
 }
-})()
+})();


### PR DESCRIPTION
Added missing tailing semi-colon - lack of which breaks JS concatenated environments (e.g. with Gulp). When Switchery is concat'ed with other JS libs like Gulp, resulting JS file is broken due to the lack of this trailing semicolon.