### PR TITLE
checkboxes crush bug fix

### DIFF
--- a/switchery.js
+++ b/switchery.js
@@ -342,7 +342,7 @@ Switchery.prototype.isChecked = function() {
  */
 
 Switchery.prototype.isDisabled = function() {
-  return this.options.disabled || this.element.disabled || this.element.readOnly;
+  return this.options.disabled || this.element && (this.element.disabled || this.element.readOnly);
 };
 
 /**


### PR DESCRIPTION
bug happens if on page present checkboxes witch not implemented switchery
`Uncaught TypeError: Cannot read property 'disabled' of null`