### PR TITLE
Check switchery element state before changing it

### DIFF
--- a/switchery.js
+++ b/switchery.js
@@ -362,6 +362,7 @@ Switchery.prototype.destroy = function() {
  */
 
 Switchery.prototype.enable = function() {
+  if (!this.options.disabled) return;
   if (this.options.disabled) this.options.disabled = false;
   if (this.element.disabled) this.element.disabled = false;
   if (this.element.readOnly) this.element.readOnly = false;
@@ -376,6 +377,7 @@ Switchery.prototype.enable = function() {
  */
 
 Switchery.prototype.disable = function() {
+  if (this.options.disabled) return;
   if (!this.options.disabled) this.options.disabled = true;
   if (!this.element.disabled) this.element.disabled = true;
   if (!this.element.readOnly) this.element.readOnly = true;


### PR DESCRIPTION
If an element is enabled and you call element.enable(),
the enable function checks the element status and if the action (enable)
and state (enabled) are the same it stops before doing anything or changing the element.
Otherwise enabling an already enabled element,
would break the functionality for this switchery element.
Same for disabling an element.

Resolves #103 
