### PR TITLE
fix dependency: fastclick's version Text

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,7 +29,7 @@
   ],
   "dependencies": {
     "transitionize": "*",
-    "fastclick": "v0.6.11"
+    "fastclick": "0.6.11"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
should be "0.6.11", not "v0.6.11", will cause maven error from webjars's  org.webjars.bower:switchery:0.8.2 to conflict with fastclick
see: http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.webjars.bower%22%20AND%20a%3A%22fastclick%22