### PR TITLE
Repository conflict https://github.com/antonamurskiy/switchery

### DIFF
--- a/examples/browserify.js
+++ b/examples/browserify.js
@@ -1,0 +1,9 @@
+switchie = document.createElement('input')
+switchie.id = 'js-switch'
+switchie.type = 'checkbox'
+
+document.body.appendChild(switchie);
+
+var Switchery = require('../switchery');
+var elem = document.querySelector('#js-switch');
+var init = new Switchery(elem);

--- a/package.json
+++ b/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "switchery-browserify",
+  "version": "0.0.0",
+  "description": "Browserify version of Switchery",
+  "main": "switchery.js",
+  "directories": {
+    "example": "examples"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/antonamurskiy/switchery.git"
+  },
+  "keywords": [
+    "switchery"
+  ],
+  "author": "Alexander Petkov",
+  "license": "MIT",
+  "contributors": [
+    "Anton Amurskiy <antonamurskiy@gmail.com>"
+  ],
+  "bugs": {
+    "url": "https://github.com/antonamurskiy/switchery/issues"
+  },
+  "browserify": {
+    "transform": "cssify"
+  },
+  "dependencies": {
+    "cssify": "~0.3.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "switchery-browserify",
+  "name": "switchery",
   "version": "0.0.2",
   "description": "Browserify version of Switchery",
   "main": "switchery.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchery-browserify",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "Browserify version of Switchery",
   "main": "switchery.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "switchery-browserify",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Browserify version of Switchery",
   "main": "switchery.js",
   "directories": {

--- a/switchery.js
+++ b/switchery.js
@@ -31,7 +31,9 @@ var defaults = {
   , speed    : '0.1s'
 };
 
-require('./switchery.css');
+if (process.browser != null) {
+  require('./switchery.css');
+}
 
 /**
  * Create Switchery object.

--- a/switchery.js
+++ b/switchery.js
@@ -31,6 +31,8 @@ var defaults = {
   , speed    : '0.1s'
 };
 
+require('./switchery.css');
+
 /**
  * Create Switchery object.
  *


### PR DESCRIPTION
Please remove https://github.com/antonamurskiy/switchery on repository github.

Cause https://github.com/antonamurskiy/switchery repository conflict with original (non-forked)

`https://github.com/abpetkov/switchery`

As conflict as `yarn add switchery`